### PR TITLE
Added tool support.

### DIFF
--- a/src/Cake.Frosting.Example/Cake.Frosting.Example.csproj
+++ b/src/Cake.Frosting.Example/Cake.Frosting.Example.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Copyright>Copyright (c) .NET Foundation and contributors</Copyright>
     <Authors>Patrik Svensson, Mattias Karlsson, Gary Ewan Park and contributors</Authors>
@@ -20,9 +19,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Cake.Frosting\Cake.Frosting.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Cake.Frosting.Example/Program.cs
+++ b/src/Cake.Frosting.Example/Program.cs
@@ -12,11 +12,6 @@ namespace Cake.Frosting.Example
             var host = new CakeHostBuilder()
                 .UseStartup<Startup>()
                 .WithArguments(args)
-                .ConfigureServices(services =>
-                {
-                    // You could also configure services like this.
-                    services.UseContext<Settings>();
-                })
                 .Build();
 
             // Run the host.
@@ -29,7 +24,6 @@ namespace Cake.Frosting.Example
         public void Configure(ICakeServices services)
         {
             services.UseContext<Settings>();
-            services.UseWorkingDirectory(".");
         }
     }
 }

--- a/src/Cake.Frosting.Tests/Data/DummyPackageInstaller.cs
+++ b/src/Cake.Frosting.Tests/Data/DummyPackageInstaller.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Cake.Core.IO;
+using Cake.Core.Packaging;
+
+namespace Cake.Frosting.Tests.Data
+{
+    public class DummyPackageInstaller : IPackageInstaller
+    {
+        public bool CanInstall(PackageReference package, PackageType type)
+        {
+            return true;
+        }
+
+        public IReadOnlyCollection<IFile> Install(PackageReference package, PackageType type, DirectoryPath path)
+        {
+            return new List<IFile>();
+        }
+    }
+}

--- a/src/Cake.Frosting.Tests/Fixtures/CakeHostBuilderFixture.cs
+++ b/src/Cake.Frosting.Tests/Fixtures/CakeHostBuilderFixture.cs
@@ -21,6 +21,7 @@ namespace Cake.Frosting.Tests.Fixtures
         public ICakeEngine Engine { get; set; }
         public ICakeLog Log { get; set; }
         public IExecutionStrategy Strategy { get; set; }
+        public IToolInstaller Installer { get; set; }
         public CakeHostOptions Options { get; set; }
 
         public CakeHostBuilderFixture()
@@ -33,16 +34,19 @@ namespace Cake.Frosting.Tests.Fixtures
 
             Log = Substitute.For<ICakeLog>();
             Engine = new CakeEngine(Log);
+            Installer = Substitute.For<IToolInstaller>();
             Options = new CakeHostOptions();
         }
 
         public ICakeHost Build()
         {
+            // Replace registrations with more suitable ones.
             Builder.ConfigureServices(s => s.RegisterType<NullConsole>().As<IConsole>());
             Builder.ConfigureServices(s => s.RegisterInstance(Environment).As<ICakeEnvironment>());
             Builder.ConfigureServices(s => s.RegisterInstance(FileSystem).As<IFileSystem>());
             Builder.ConfigureServices(s => s.RegisterInstance(Engine).As<ICakeEngine>());
             Builder.ConfigureServices(s => s.RegisterInstance(Log).As<ICakeLog>());
+            Builder.ConfigureServices(s => s.RegisterInstance(Installer).As<IToolInstaller>());
             Builder.ConfigureServices(s => s.RegisterInstance(Options).As<CakeHostOptions>());
 
             if (Strategy != null)

--- a/src/Cake.Frosting.Tests/Unit/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/Unit/CakeHostTests.cs
@@ -5,6 +5,7 @@
 using System;
 using Cake.Core;
 using Cake.Core.Diagnostics;
+using Cake.Core.Packaging;
 using Cake.Frosting.Testing;
 using Cake.Frosting.Tests.Data.Tasks;
 using Cake.Frosting.Tests.Fakes;
@@ -377,6 +378,22 @@ namespace Cake.Frosting.Tests.Unit
                 fixture.Log.Information("OnError method called");
                 fixture.Log.Information("Finally method called");
             });
+        }
+
+        [Fact]
+        public void Should_Install_Tools()
+        {
+            // Given
+            var fixture = new CakeHostBuilderFixture();
+            fixture.Builder.ConfigureServices(s => s.UseTool(new Uri("foo:?package=Bar")));
+            fixture.RegisterDefaultTask();
+
+            // When
+            fixture.Run();
+
+            // Then
+            fixture.Installer.Received(1).Install(Arg.Is<PackageReference>(
+                p => p.OriginalString == "foo:?package=Bar"));
         }
     }
 }

--- a/src/Cake.Frosting.Tests/Unit/Extensions/CakeHostBuilderExtensionsTests.cs
+++ b/src/Cake.Frosting.Tests/Unit/Extensions/CakeHostBuilderExtensionsTests.cs
@@ -42,7 +42,7 @@ namespace Cake.Frosting.Tests.Unit.Extensions
             }
         }
 
-        public sealed class TheBuildExtensionMethod
+        public sealed class TheWithArgumentsMethod
         {
             [Fact]
             public void Should_Throw_If_Builder_Reference_Is_Null()

--- a/src/Cake.Frosting.sln
+++ b/src/Cake.Frosting.sln
@@ -1,16 +1,10 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26206.0
+VisualStudioVersion = 15.0.26127.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cake.Frosting", "Cake.Frosting\Cake.Frosting.csproj", "{A608FD39-2B71-4B6E-B238-AE80BB2794F8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cake.Frosting.Example", "Cake.Frosting.Example\Cake.Frosting.Example.csproj", "{ED379398-DA69-4D1E-B712-27DC0D67ABC3}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Meta", "Meta", "{E00C4E89-C607-4B5E-9C48-A8BFC8903FB7}"
-	ProjectSection(SolutionItems) = preProject
-		Frosting.ruleset = Frosting.ruleset
-		stylecop.json = stylecop.json
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cake.Frosting.Testing", "Cake.Frosting.Testing\Cake.Frosting.Testing.csproj", "{778E6393-6768-407C-8795-7A3C4A51579F}"
 EndProject

--- a/src/Cake.Frosting/Abstractions/IToolInstaller.cs
+++ b/src/Cake.Frosting/Abstractions/IToolInstaller.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Cake.Core.Packaging;
+
+// ReSharper disable once CheckNamespace
+namespace Cake.Frosting
+{
+    /// <summary>
+    /// Represents the tool installer.
+    /// </summary>
+    public interface IToolInstaller
+    {
+        /// <summary>
+        /// Tries to install the specified <see cref="PackageReference"/> using
+        /// the most suitable <see cref="IPackageInstaller"/>.
+        /// </summary>
+        /// <param name="tool"></param>
+        void Install(PackageReference tool);
+    }
+}

--- a/src/Cake.Frosting/Cake.Frosting.csproj
+++ b/src/Cake.Frosting/Cake.Frosting.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <PackageId>Cake.Frosting</PackageId>
     <Description>The .NET Core host for Cake.</Description>
@@ -21,14 +20,11 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.17.0" />
     <PackageReference Include="Cake.Common" Version="0.17.0" />
   </ItemGroup>
-
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  
 </Project>

--- a/src/Cake.Frosting/CakeHostBuilderExtensions.cs
+++ b/src/Cake.Frosting/CakeHostBuilderExtensions.cs
@@ -5,7 +5,6 @@
 using Cake.Frosting.Internal;
 using Cake.Frosting.Internal.Arguments;
 
-// ReSharper disable once CheckNamespace
 namespace Cake.Frosting
 {
     /// <summary>

--- a/src/Cake.Frosting/CakeServicesExtensions.cs
+++ b/src/Cake.Frosting/CakeServicesExtensions.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Reflection;
 using Cake.Core.Composition;
 using Cake.Core.IO;
+using Cake.Core.Packaging;
 using Cake.Frosting.Internal;
 
-// ReSharper disable once CheckNamespace
 namespace Cake.Frosting
 {
     /// <summary>
@@ -80,15 +81,15 @@ namespace Cake.Frosting
         /// <summary>
         /// Registers the specified module type.
         /// </summary>
-        /// <typeparam name="T">The type of the module</typeparam>
+        /// <typeparam name="TModule">The type of the module.</typeparam>
         /// <param name="services">The service registration collection.</param>
         /// <returns>The same <see cref="ICakeServices"/> instance so that multiple calls can be chained.</returns>
-        public static ICakeServices UseModule<T>(this ICakeServices services)
-            where T : ICakeModule, new()
+        public static ICakeServices UseModule<TModule>(this ICakeServices services)
+            where TModule : ICakeModule, new()
         {
             Guard.ArgumentNotNull(services, nameof(services));
 
-            var module = new T();
+            var module = new TModule();
             module.Register(services);
             return services;
         }
@@ -120,6 +121,36 @@ namespace Cake.Frosting
 
             var info = new ConfigurationSetting(key, value);
             services.RegisterInstance(info).AsSelf().Singleton();
+            return services;
+        }
+
+        /// <summary>
+        /// Registers a specific tool for installation.
+        /// </summary>
+        /// <typeparam name="TPackageInstaller">The type of the package installer.</typeparam>
+        /// <param name="services">The service registration collection.</param>
+        /// <returns>The same <see cref="ICakeServices"/> instance so that multiple calls can be chained.</returns>
+        public static ICakeServices UsePackageInstaller<TPackageInstaller>(this ICakeServices services)
+            where TPackageInstaller : IPackageInstaller
+        {
+            Guard.ArgumentNotNull(services, nameof(services));
+
+            services.RegisterType<TPackageInstaller>().As<IPackageInstaller>().Singleton();
+            return services;
+        }
+
+        /// <summary>
+        /// Registers a specific tool for installation.
+        /// </summary>
+        /// <param name="services">The service registration collection.</param>
+        /// <param name="uri">The tool URI.</param>
+        /// <returns>The same <see cref="ICakeServices"/> instance so that multiple calls can be chained.</returns>
+        public static ICakeServices UseTool(this ICakeServices services, Uri uri)
+        {
+            Guard.ArgumentNotNull(services, nameof(services));
+
+            var package = new PackageReference(uri.OriginalString);
+            services.RegisterInstance(package).Singleton();
             return services;
         }
     }

--- a/src/Cake.Frosting/Internal/Module.cs
+++ b/src/Cake.Frosting/Internal/Module.cs
@@ -46,6 +46,9 @@ namespace Cake.Frosting
             registry.RegisterType<ReportPrinter>().As<ICakeReportPrinter>().Singleton();
             registry.RegisterType<RawArguments>().As<ICakeArguments>().Singleton();
 
+            // Tooling
+            registry.RegisterType<ToolInstaller>().As<IToolInstaller>().Singleton();
+
             // Register default stuff.
             registry.RegisterType<FrostingContext>().AsSelf().As<IFrostingContext>().Singleton();
             registry.RegisterType<CakeHostOptions>().AsSelf().Singleton();

--- a/src/Cake.Frosting/Internal/ToolInstaller.cs
+++ b/src/Cake.Frosting/Internal/ToolInstaller.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Cake.Core;
+using Cake.Core.Packaging;
+using Cake.Core.Tooling;
+
+namespace Cake.Frosting.Internal
+{
+    internal sealed class ToolInstaller : IToolInstaller
+    {
+        private readonly ICakeEnvironment _environment;
+        private readonly IToolLocator _locator;
+        private readonly List<IPackageInstaller> _installers;
+
+        public ToolInstaller(ICakeEnvironment environment, IToolLocator locator, IEnumerable<IPackageInstaller> installers)
+        {
+            _environment = environment;
+            _locator = locator;
+            _installers = new List<IPackageInstaller>(installers ?? Enumerable.Empty<IPackageInstaller>());
+        }
+
+        public void Install(PackageReference tool)
+        {
+            // Get the tool path.
+            var root = _environment.WorkingDirectory.Combine("tools").MakeAbsolute(_environment);
+
+            // Get the installer.
+            var installer = _installers.FirstOrDefault(i => i.CanInstall(tool, PackageType.Tool));
+            if (installer == null)
+            {
+                const string format = "Could not find an installer for the '{0}' scheme.";
+                var message = string.Format(CultureInfo.InvariantCulture, format, tool.Scheme);
+                throw new FrostingException(message);
+            }
+
+            // Install the tool.
+            var result = installer.Install(tool, PackageType.Tool, root);
+            if (result.Count == 0)
+            {
+                const string format = "Failed to install tool '{0}'.";
+                var message = string.Format(CultureInfo.InvariantCulture, format, tool.Package);
+                throw new FrostingException(message);
+            }
+
+            // Register the tools.
+            foreach (var item in result)
+            {
+                _locator.RegisterFile(item.Path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Only infrastructure in this PR.
The actual package installers will be submitted in separate PR:s.

Example of usage:

```csharp
public class Startup : IFrostingStartup
{
    public void Configure(ICakeServices services)
    {
        // Register a package installer (not included in PR).
        services.UsePackageInstaller<RSyncInstaller>();

        // Define tools to be installed
        services.UseTool(new Uri("rsync:?package=cygwin"));
    }
}
```

Or inject the installer facade into something directly.

```csharp
public class MyTask : FrostingTask
{
    private readonly IToolInstaller _installer;

    public MyTask(IToolInstaller installer)
    {
        _installer = installer;
    }

    public over void Run(FrostingContext context)
    {
        _installer.Install(new PackageReference("rsync:?package=cygwin"));
    }
}
```