### PR TITLE
Support async tasks

### DIFF
--- a/src/Cake.Frosting.Example/Tasks.cs
+++ b/src/Cake.Frosting.Example/Tasks.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 
@@ -12,8 +13,15 @@ namespace Cake.Frosting.Example
     }
 
     [Dependency(typeof(Hello))]
-    public sealed class World : FrostingTask<Settings>
+    public sealed class World : AsyncFrostingTask<Settings>
     {
+        // Tasks can be asynchronous
+        public override async Task RunAsync(Settings context)
+        {
+            context.Log.Information("About to do something expensive");
+            await Task.Delay(1500);
+            context.Log.Information("Done");
+        }
     }
 
     [Dependency(typeof(World))]

--- a/src/Cake.Frosting.Tests/Data/Tasks/OnErrorRunAsyncFailedTask.cs
+++ b/src/Cake.Frosting.Tests/Data/Tasks/OnErrorRunAsyncFailedTask.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+
+namespace Cake.Frosting.Tests.Data.Tasks
+{
+    [TaskName("On-Error-RunAsync-Failed")]
+    public sealed class OnErrorRunAsyncFailedTask : AsyncFrostingTask<ICakeContext>
+    {
+        public override Task RunAsync(ICakeContext context)
+        {
+            throw new InvalidOperationException("On test exception");
+        }
+
+        public override void OnError(Exception exception, ICakeContext context)
+        {
+            context.Log.Error("An error has occurred. {0}", exception.Message);
+        }
+    }
+}

--- a/src/Cake.Frosting.Tests/Unit/CakeHostTests.cs
+++ b/src/Cake.Frosting.Tests/Unit/CakeHostTests.cs
@@ -346,6 +346,21 @@ namespace Cake.Frosting.Tests.Unit
         }
 
         [Fact]
+        public void Should_Execute_OnError_Method_If_RunAsync_Failed()
+        {
+            // Given
+            var fixture = new CakeHostBuilderFixture();
+            fixture.RegisterTask<OnErrorRunAsyncFailedTask>();
+            fixture.Options.Target = "On-Error-RunAsync-Failed";
+
+            // When
+            fixture.Run();
+
+            // Then
+            fixture.Log.Received(1).Error("An error has occurred. {0}", "On test exception");
+        }
+
+        [Fact]
         public void Should_Not_Execute_OnError_Method_If_Run_Completed()
         {
             // Given

--- a/src/Cake.Frosting/Abstractions/IFrostingTask.cs
+++ b/src/Cake.Frosting/Abstractions/IFrostingTask.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using Cake.Core;
 
 // ReSharper disable once CheckNamespace
@@ -17,7 +18,7 @@ namespace Cake.Frosting
         /// Runs the task using the specified context.
         /// </summary>
         /// <param name="context">The context.</param>
-        void Run(ICakeContext context);
+        Task RunAsync(ICakeContext context);
 
         /// <summary>
         /// Gets whether or not the task should be run.

--- a/src/Cake.Frosting/AsyncFrostingTask.cs
+++ b/src/Cake.Frosting/AsyncFrostingTask.cs
@@ -11,27 +11,28 @@ using Cake.Frosting.Internal;
 namespace Cake.Frosting
 {
     /// <summary>
-    /// Base class for a Frosting task using the standard context.
+    /// Base class for an asynchronous Frosting task using the standard context.
     /// </summary>
     /// <seealso cref="ICakeContext" />
-    public abstract class FrostingTask : FrostingTask<ICakeContext>
+    public abstract class AsyncFrostingTask : AsyncFrostingTask<ICakeContext>
     {
     }
 
     /// <summary>
-    /// Base class for a Frosting task using a custom context.
+    /// Base class for an asynchronous Frosting task using a custom context.
     /// </summary>
     /// <typeparam name="T">The context type.</typeparam>
     /// <seealso cref="IFrostingTask" />
-    public abstract class FrostingTask<T> : IFrostingTask
+    public abstract class AsyncFrostingTask<T> : IFrostingTask
         where T : ICakeContext
     {
         /// <summary>
         /// Runs the task using the specified context.
         /// </summary>
         /// <param name="context">The context.</param>
-        public virtual void Run(T context)
+        public virtual Task RunAsync(T context)
         {
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -68,8 +69,7 @@ namespace Cake.Frosting
         {
             Guard.ArgumentNotNull(context, nameof(context));
 
-            Run((T)context);
-            return Task.CompletedTask;
+            return RunAsync((T)context);
         }
 
         [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Explicit implementation.")]

--- a/src/Cake.Frosting/CakeHost.cs
+++ b/src/Cake.Frosting/CakeHost.cs
@@ -98,7 +98,7 @@ namespace Cake.Frosting
 
                 // Get the command and execute.
                 var command = _commandFactory.GetCommand(_options);
-                var result = command.Execute(_engine, _options);
+                var result = command.ExecuteAsync(_engine, _options).GetAwaiter().GetResult();
 
                 // Return success.
                 return result ? 0 : 1;

--- a/src/Cake.Frosting/Internal/Commands/Command.cs
+++ b/src/Cake.Frosting/Internal/Commands/Command.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Cake.Core;
 
 namespace Cake.Frosting.Internal.Commands
 {
     internal abstract class Command
     {
-        public abstract bool Execute(ICakeEngine engine, CakeHostOptions options);
+        public abstract Task<bool> ExecuteAsync(ICakeEngine engine, CakeHostOptions options);
     }
 }

--- a/src/Cake.Frosting/Internal/Commands/DryRunCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/DryRunCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Cake.Core;
 using Cake.Core.Diagnostics;
 
@@ -20,16 +21,16 @@ namespace Cake.Frosting.Internal.Commands
             _executionSettings = new ExecutionSettings();
         }
 
-        public override bool Execute(ICakeEngine engine, CakeHostOptions options)
+        public override async Task<bool> ExecuteAsync(ICakeEngine engine, CakeHostOptions options)
         {
             _executionSettings.SetTarget(options.Target);
-            
+
             _log.Information("Performing dry run...");
             _log.Information("Target is: {0}", options.Target);
             _log.Information(string.Empty);
 
             var strategy = new DryRunExecutionStrategy(_log);
-            engine.RunTargetAsync(_context, strategy, _executionSettings).GetAwaiter().GetResult();
+            await engine.RunTargetAsync(_context, strategy, _executionSettings).ConfigureAwait(false);
 
             _log.Information(string.Empty);
             _log.Information("This was a dry run.");

--- a/src/Cake.Frosting/Internal/Commands/DryRunExecutionStrategy.cs
+++ b/src/Cake.Frosting/Internal/Commands/DryRunExecutionStrategy.cs
@@ -35,6 +35,7 @@ namespace Cake.Frosting.Internal.Commands
                 _log.Information("{0}. {1}", _counter, task.Name);
                 _counter++;
             }
+
             return Task.CompletedTask;
         }
 

--- a/src/Cake.Frosting/Internal/Commands/ErrorDecoratorCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/ErrorDecoratorCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Cake.Core;
 
 namespace Cake.Frosting.Internal.Commands
@@ -15,9 +16,9 @@ namespace Cake.Frosting.Internal.Commands
             _command = command;
         }
 
-        public override bool Execute(ICakeEngine engine, CakeHostOptions options)
+        public override async Task<bool> ExecuteAsync(ICakeEngine engine, CakeHostOptions options)
         {
-            _command.Execute(engine, options);
+            await _command.ExecuteAsync(engine, options).ConfigureAwait(false);
             return false;
         }
     }

--- a/src/Cake.Frosting/Internal/Commands/HelpCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/HelpCommand.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
 using Cake.Core;
 
 namespace Cake.Frosting.Internal.Commands
@@ -17,7 +18,7 @@ namespace Cake.Frosting.Internal.Commands
             _console = console;
         }
 
-        public override bool Execute(ICakeEngine engine, CakeHostOptions options)
+        public override Task<bool> ExecuteAsync(ICakeEngine engine, CakeHostOptions options)
         {
             _console.Write("Cake.Frosting (");
             _console.ForegroundColor = ConsoleColor.Yellow;
@@ -37,7 +38,7 @@ namespace Cake.Frosting.Internal.Commands
             _console.WriteLine("  --help|-h                     Show help");
             _console.WriteLine();
 
-            return true;
+            return Task.FromResult(true);
         }
     }
 }

--- a/src/Cake.Frosting/Internal/Commands/RunCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/RunCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading.Tasks;
 using Cake.Core;
 
 namespace Cake.Frosting.Internal.Commands
@@ -25,10 +26,10 @@ namespace Cake.Frosting.Internal.Commands
             _executionSettings = new ExecutionSettings();
         }
 
-        public override bool Execute(ICakeEngine engine, CakeHostOptions options)
+        public override async Task<bool> ExecuteAsync(ICakeEngine engine, CakeHostOptions options)
         {
             _executionSettings.SetTarget(options.Target);
-            var report = engine.RunTargetAsync(_context, _strategy, _executionSettings).GetAwaiter().GetResult();
+            var report = await engine.RunTargetAsync(_context, _strategy, _executionSettings).ConfigureAwait(false);
             if (report != null && !report.IsEmpty)
             {
                 _printer.Write(report);

--- a/src/Cake.Frosting/Internal/Commands/VersionCommand.cs
+++ b/src/Cake.Frosting/Internal/Commands/VersionCommand.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
+using System.Threading.Tasks;
 using Cake.Core;
 
 namespace Cake.Frosting.Internal.Commands
@@ -16,10 +17,10 @@ namespace Cake.Frosting.Internal.Commands
             _console = console;
         }
 
-        public override bool Execute(ICakeEngine engine, CakeHostOptions options)
+        public override Task<bool> ExecuteAsync(ICakeEngine engine, CakeHostOptions options)
         {
             _console.Write(typeof(HelpCommand).GetTypeInfo().Assembly.GetName().Version.ToString(3));
-            return true;
+            return Task.FromResult(true);
         }
     }
 }

--- a/src/Cake.Frosting/Internal/EngineInitializer.cs
+++ b/src/Cake.Frosting/Internal/EngineInitializer.cs
@@ -42,7 +42,7 @@ namespace Cake.Frosting.Internal
                         // Is the run method overridden?
                         if (task.IsRunOverridden(context))
                         {
-                            cakeTask.Does(c => task.Run(c));
+                            cakeTask.Does(task.RunAsync);
                         }
 
                         // Is the criteria method overridden?


### PR DESCRIPTION
Fixes #45.

So I just really bumped Cake to `0.23` and made my way through the errors that popped up.

The only bit I had to tweak is the detection of whether the task has a `Does` component in `EngineInitializer` as now either `Run` or `RunAsync` can now be overridden. Do we want to issue a warning if both of them are overridden as only one should be?

Also, please let me know if you see any specific tests we should add to be more confident about this change.

Thanks 👍 